### PR TITLE
Get design from document

### DIFF
--- a/plethora_internal.py
+++ b/plethora_internal.py
@@ -190,9 +190,8 @@ def create_order(data):
     
 def analyze(material):
 
-    # get active design
-    product = _app.activeProduct
-    design = adsk.fusion.Design.cast(product)
+    # get design
+    design = adsk.fusion.Design.cast(_app.activeDocument.design)
     
     # check for bodies
     if design.activeComponent.bRepBodies.count == 0:


### PR DESCRIPTION
This PR fixes the issue that if anything other than the `Model` workspace was selected analyzing would fail.